### PR TITLE
Rewrite label names to be Prometheus compliant

### DIFF
--- a/web/app/models/OpenTsdbQueryResult.scala
+++ b/web/app/models/OpenTsdbQueryResult.scala
@@ -101,10 +101,10 @@ object TsdbQueryResult {
       )
   )
 
-  def sanitizeTagName(label: String): String = label
-    .replaceFirst("^[^\\p{L}_:]", ":")
-    .replaceAll("[^\\p{L}0-9_:]+", "_")
-
-  def sanitizeTags(prometheusTags: Map[String, String]): Map[String, String] =
+  def sanitizeTags(prometheusTags: Map[String, String]): Map[String, String] = {
+    def sanitizeTagName(label: String): String = label
+      .replaceFirst("^[^\\p{L}_:]", ":")
+      .replaceAll("[^\\p{L}0-9_:]+", "_")
     prometheusTags.map { case (key, value) => (sanitizeTagName(key), value) }
+  }
 }

--- a/web/app/models/OpenTsdbQueryResult.scala
+++ b/web/app/models/OpenTsdbQueryResult.scala
@@ -42,7 +42,7 @@ case class TsdbQueryResult(
       mapping <- metric.query.mappings.find(_.subQuery == subQuery)
       tags <- mergeTags(mapping.prometheusTags)
       dp <- latestDataPoint
-    } yield PrometheusMetric(metric.name, metric.description, metric.metricType, tags, dp.value)
+    } yield PrometheusMetric(metric.name, metric.description, metric.metricType, TsdbQueryResult.sanitizeTags(tags), dp.value)
   }
 }
 
@@ -100,4 +100,11 @@ object TsdbQueryResult {
         subQuery = query
       )
   )
+
+  def sanitizeTagName(label: String): String = label
+    .replaceFirst("^[^\\p{L}_:]", ":")
+    .replaceAll("[^\\p{L}0-9_:]+", "_")
+
+  def sanitizeTags(prometheusTags: Map[String, String]): Map[String, String] =
+    prometheusTags.map { case (key, value) => (sanitizeTagName(key), value) }
 }

--- a/web/test/MetricsControllerSpec.scala
+++ b/web/test/MetricsControllerSpec.scala
@@ -78,10 +78,10 @@ class MetricsControllerSpec extends PlaySpec
         output must contain theSameElementsInOrderAs List(
           "# HELP test_app_metrics_one TestApp metrics: one",
           "# TYPE test_app_metrics_one counter",
-          """test_app_metrics_one{severity="critical",escalation="pagerduty",role="developer"} 15.0""",
+          """test_app_metrics_one{severity="critical",escalation="pagerduty",user_role="developer"} 15.0""",
           "# HELP test_app_metrics_two TestApp metrics: two",
           "# TYPE test_app_metrics_two counter",
-          """test_app_metrics_two{severity="critical",escalation="pagerduty",role="developer"} 10.0"""
+          """test_app_metrics_two{severity="critical",escalation="pagerduty",user_role="developer"} 10.0"""
         )
       }
     }
@@ -96,7 +96,7 @@ class SimpleOpenTsdbWSMock extends OpenTsdbWSMock {
         |  {
         |    "metric": "test.app.metrics.one",
         |    "tags": {
-        |      "role": "developer"
+        |      "user.role": "developer"
         |    },
         |    "aggregateTags": [],
         |    "query": {
@@ -107,7 +107,7 @@ class SimpleOpenTsdbWSMock extends OpenTsdbWSMock {
         |      "rate": false,
         |      "filters": [
         |        {
-        |          "tagk": "role",
+        |          "tagk": "user.role",
         |          "filter": "developer",
         |          "group_by": true,
         |          "type": "literal_or"
@@ -115,7 +115,7 @@ class SimpleOpenTsdbWSMock extends OpenTsdbWSMock {
         |      ],
         |      "rateOptions": null,
         |      "tags": {
-        |        "role": "literal_or(developer)"
+        |        "user.role": "literal_or(developer)"
         |      }
         |    },
         |    "dps": {
@@ -139,7 +139,7 @@ class SimpleOpenTsdbWSMock extends OpenTsdbWSMock {
         |  {
         |    "metric": "test.app.metrics.two",
         |    "tags": {
-        |      "role": "developer"
+        |      "user.role": "developer"
         |    },
         |    "aggregateTags": [],
         |    "query": {
@@ -150,7 +150,7 @@ class SimpleOpenTsdbWSMock extends OpenTsdbWSMock {
         |      "rate": false,
         |      "filters": [
         |        {
-        |          "tagk": "role",
+        |          "tagk": "user.role",
         |          "filter": "developer",
         |          "group_by": true,
         |          "type": "literal_or"
@@ -158,7 +158,7 @@ class SimpleOpenTsdbWSMock extends OpenTsdbWSMock {
         |      ],
         |      "rateOptions": null,
         |      "tags": {
-        |        "role": "literal_or(developer)"
+        |        "user.role": "literal_or(developer)"
         |      }
         |    },
         |    "dps": {

--- a/web/test/data/test.app.metrics.one.json
+++ b/web/test/data/test.app.metrics.one.json
@@ -15,7 +15,7 @@
             "aggregator": "avg",
             "rate": false,
             "tags": {
-              "role": "developer"
+              "user.role": "developer"
             }
           },
           "prometheusTags": {

--- a/web/test/data/test.app.metrics.two.json
+++ b/web/test/data/test.app.metrics.two.json
@@ -15,7 +15,7 @@
             "aggregator": "avg",
             "rate": false,
             "tags": {
-              "role": "developer"
+              "user.role": "developer"
             }
           },
           "prometheusTags": {
@@ -29,7 +29,7 @@
             "aggregator": "avg",
             "rate": false,
             "tags": {
-              "role": "developer"
+              "user.role": "developer"
             }
           },
           "prometheusTags": {

--- a/web/test/models/OpenTsdbQueryResultSpec.scala
+++ b/web/test/models/OpenTsdbQueryResultSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * ADOBE CONFIDENTIAL
+ * ___________________
+ *
+ * Copyright 2020 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains
+ * the property of Adobe and its suppliers, if any. The intellectual
+ * and technical concepts contained herein are proprietary to Adobe
+ * and its suppliers and are protected by all applicable intellectual
+ * property laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe.
+ *
+ */
+
+package models
+
+import org.scalatestplus.play.PlaySpec
+
+class OpenTsdbQueryResultSpec extends PlaySpec {
+
+  "OpenTsdbQueryResult" should {
+    "Santize tag names" in {
+      val inputs = List("abCD", "123abc", "@email", "Unic\u00F6de", "teach.me")
+      val expected = List("abCD", ":23abc", ":email", "Unic\u00F6de", "teach_me")
+      inputs.map(TsdbQueryResult.sanitizeTagName) must contain theSameElementsInOrderAs expected
+    }
+  }
+
+}

--- a/web/test/models/OpenTsdbQueryResultSpec.scala
+++ b/web/test/models/OpenTsdbQueryResultSpec.scala
@@ -1,21 +1,3 @@
-/*
- * ADOBE CONFIDENTIAL
- * ___________________
- *
- * Copyright 2020 Adobe
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains
- * the property of Adobe and its suppliers, if any. The intellectual
- * and technical concepts contained herein are proprietary to Adobe
- * and its suppliers and are protected by all applicable intellectual
- * property laws, including trade secret and copyright laws.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe.
- *
- */
-
 package models
 
 import org.scalatestplus.play.PlaySpec

--- a/web/test/models/OpenTsdbQueryResultSpec.scala
+++ b/web/test/models/OpenTsdbQueryResultSpec.scala
@@ -6,9 +6,9 @@ class OpenTsdbQueryResultSpec extends PlaySpec {
 
   "OpenTsdbQueryResult" should {
     "Santize tag names" in {
-      val inputs = List("abCD", "123abc", "@email", "Unic\u00F6de", "teach.me")
-      val expected = List("abCD", ":23abc", ":email", "Unic\u00F6de", "teach_me")
-      inputs.map(TsdbQueryResult.sanitizeTagName) must contain theSameElementsInOrderAs expected
+      val inputs = Map("abCD" -> "1", "123abc" -> "2", "@email" -> "3", "Unic\u00F6de" -> "4", "teach.me" -> "5")
+      val expected = Map("abCD" -> "1", ":23abc" -> "2", ":email" -> "3", "Unic\u00F6de" -> "4", "teach_me" -> "5")
+      TsdbQueryResult.sanitizeTags(inputs) must contain theSameElementsAs expected
     }
   }
 


### PR DESCRIPTION
I am running into issues where my OpenTSDB tags with periods in their names are failing to be scraped by Prometheus. It seems like the most logical place to fix that is in this exporter. This approach takes any tag name that would fail validation in Prometheus and rewrites it to pass.